### PR TITLE
Locking fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ dkms build -m t150 -v $VERSION
 dkms install -m t150 -v $VERSION
 
 echo "==== SET UP LOAD AT BOOT ===="
-sed '/t150/d' /etc/modules
-sed '/hid-tminit/d' /etc/modules
+sed -i '/t150/d' /etc/modules
+sed -i '/hid-tminit/d' /etc/modules
 
 echo "t150" >> /etc/modules
 echo "hid-tminit" >> /etc/modules

--- a/t150/attributes.c
+++ b/t150/attributes.c
@@ -67,10 +67,11 @@ static ssize_t t150_show_return_force(struct device *dev, struct device_attribut
 {
 	int len;
 	struct t150 *t150 = dev_get_drvdata(dev);
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	len = sprintf(buf, "%d", t150->settings.autocenter_force);
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	return len;
 }
@@ -92,10 +93,11 @@ static ssize_t t150_show_simulate_return_force(struct device *dev, struct device
 {
 	int len;
 	struct t150 *t150 = dev_get_drvdata(dev);
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	len = sprintf(buf, "%c", t150->settings.autocenter_enabled ? 'y' : 'n');
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	return len;
 }
@@ -126,10 +128,11 @@ static ssize_t t150_show_range(struct device *dev, struct device_attribute *attr
 {
 	int len;
 	struct t150 *t150 = dev_get_drvdata(dev);
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	len = sprintf(buf, "%d", (t150->settings.range * 1080) / 0xffff);
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	return len;
 }
@@ -157,10 +160,11 @@ static ssize_t t150_show_ffb_intensity(struct device *dev, struct device_attribu
 {
 	int len;
 	struct t150 *t150 = dev_get_drvdata(dev);
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	len = sprintf(buf, "%d", (t150->settings.gain * 100) / 0x80);
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	return len;
 }
@@ -169,10 +173,11 @@ ssize_t t150_show_fw_version(struct device *dev, struct device_attribute *attr,c
 {
 	int len;
 	struct t150 *t150 = dev_get_drvdata(dev);
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	len = sprintf(buf, "%d", t150->settings.firmware_version);
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	return len;
 }

--- a/t150/forcefeedback.c
+++ b/t150/forcefeedback.c
@@ -399,6 +399,7 @@ static void t150_ff_set_gain(struct input_dev *dev, uint16_t gain)
 	int errno;
 	struct urb *urb;
 	struct ff_change_gain *ff_change;
+	unsigned long flags;
 
 	urb = t150_ff_alloc_urb(t150, sizeof(struct ff_change_gain));
 	if(!urb)
@@ -409,9 +410,9 @@ static void t150_ff_set_gain(struct input_dev *dev, uint16_t gain)
 	ff_change->f0 = 0x43;
 	ff_change->gain = gain / 0x1ff;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	t150->settings.gain = ff_change->gain;
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	urb->complete = t150_ff_free_urb;
 	errno = usb_submit_urb(urb, GFP_KERNEL);

--- a/t150/settings.c
+++ b/t150/settings.c
@@ -7,10 +7,12 @@ static int t150_set_gain(struct t150 *t150, uint8_t gain)
 {
 	int boh, errno;
 	uint8_t *buffer = kzalloc(2, GFP_KERNEL);
+	unsigned long flags;
+
 	buffer[0] = 0x43;
 	buffer[1] = gain;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 
 	// Send to the wheel desidered return force
 	errno = usb_interrupt_msg(
@@ -26,7 +28,7 @@ static int t150_set_gain(struct t150 *t150, uint8_t gain)
 	else
 		printk(KERN_ERR "t150: Operation set gain failed with code %d", errno);
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	kzfree(buffer);
 
@@ -40,15 +42,16 @@ static __always_inline int t150_set_autocenter(struct t150 *t150, uint8_t autoce
 {
 	uint8_t *buffer = kzalloc(4, GFP_KERNEL);
 	int errno;
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 
 	errno = t150_settings_set40(t150, SET40_RETURN_FORCE, autocenter_force, buffer);
 
 	if(!errno)
 		t150->settings.autocenter_force = autocenter_force;
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	kzfree(buffer);
 	return errno;
@@ -62,15 +65,16 @@ static __always_inline int t150_set_enable_autocenter(struct t150 *t150, bool en
 {
 	uint8_t *buffer = kzalloc(4, GFP_KERNEL);
 	int errno;
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 
 	errno = t150_settings_set40(t150, SET40_USE_RETURN_FORCE, enable, buffer);
 
 	if(!errno)
 		t150->settings.autocenter_enabled = enable;
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	kzfree(buffer);
 	return errno;
@@ -84,15 +88,16 @@ static __always_inline int t150_set_range(struct t150 *t150, uint16_t range)
 {
 	uint8_t *buffer = kzalloc(4, GFP_KERNEL);
 	int errno;
+	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 
 	errno = t150_settings_set40(t150, SET40_RANGE, range, buffer);
 
 	if(!errno)
 		t150->settings.range = range;
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	kzfree(buffer);
 	return errno;
@@ -137,17 +142,18 @@ static int t150_setup_task(struct t150 *t150)
 {
 	int errno = 0;
 	uint8_t *fw_version;
+	unsigned long flags;
 
 	fw_version = kzalloc(8, GFP_KERNEL);
 
 	// Retrive current version
-	spin_lock_irqsave(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	errno = usb_control_msg(
 		t150->usb_device,
 		usb_rcvctrlpipe(t150->usb_device, 0),
 		86, 0xc1, 0, 0, fw_version, 8, SETTINGS_TIMEOUT
 	);
-	spin_unlock_irqrestore(&t150->settings.access_lock, t150->settings.access_lock_flags);
+	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	if(errno < 0)
 		printk(KERN_ERR "t150: Error %d while sending the control URB to retrive firmware version\n", errno);

--- a/t150/settings.c
+++ b/t150/settings.c
@@ -12,7 +12,7 @@ static int t150_set_gain(struct t150 *t150, uint8_t gain)
 	buffer[0] = 0x43;
 	buffer[1] = gain;
 
-	spin_lock_irqsave(&t150->settings.access_lock, flags);
+	mutex_lock(&t150->lock);
 
 	// Send to the wheel desidered return force
 	errno = usb_interrupt_msg(
@@ -23,12 +23,15 @@ static int t150_set_gain(struct t150 *t150, uint8_t gain)
 		SETTINGS_TIMEOUT
 	);
 
-	if(!errno)
+	if(!errno) {
+		spin_lock_irqsave(&t150->settings.access_lock, flags);
 		t150->settings.gain = gain;
-	else
+		spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	} else {
 		printk(KERN_ERR "t150: Operation set gain failed with code %d", errno);
+	}
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	mutex_unlock(&t150->lock);
 
 	kzfree(buffer);
 
@@ -44,14 +47,17 @@ static __always_inline int t150_set_autocenter(struct t150 *t150, uint8_t autoce
 	int errno;
 	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, flags);
+	mutex_lock(&t150->lock);
 
 	errno = t150_settings_set40(t150, SET40_RETURN_FORCE, autocenter_force, buffer);
 
-	if(!errno)
+	if(!errno) {
+		spin_lock_irqsave(&t150->settings.access_lock, flags);
 		t150->settings.autocenter_force = autocenter_force;
+		spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	}
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	mutex_unlock(&t150->lock);
 
 	kzfree(buffer);
 	return errno;
@@ -67,14 +73,17 @@ static __always_inline int t150_set_enable_autocenter(struct t150 *t150, bool en
 	int errno;
 	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, flags);
+	mutex_lock(&t150->lock);
 
 	errno = t150_settings_set40(t150, SET40_USE_RETURN_FORCE, enable, buffer);
 
-	if(!errno)
+	if(!errno) {
+		spin_lock_irqsave(&t150->settings.access_lock, flags);
 		t150->settings.autocenter_enabled = enable;
+		spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	}
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	mutex_unlock(&t150->lock);
 
 	kzfree(buffer);
 	return errno;
@@ -90,14 +99,17 @@ static __always_inline int t150_set_range(struct t150 *t150, uint16_t range)
 	int errno;
 	unsigned long flags;
 
-	spin_lock_irqsave(&t150->settings.access_lock, flags);
+	mutex_lock(&t150->lock);
 
 	errno = t150_settings_set40(t150, SET40_RANGE, range, buffer);
 
-	if(!errno)
+	if(!errno) {
+		spin_lock_irqsave(&t150->settings.access_lock, flags);
 		t150->settings.range = range;
+		spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	}
 
-	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+	mutex_unlock(&t150->lock);
 
 	kzfree(buffer);
 	return errno;
@@ -142,18 +154,19 @@ static int t150_setup_task(struct t150 *t150)
 {
 	int errno = 0;
 	uint8_t *fw_version;
-	unsigned long flags;
 
 	fw_version = kzalloc(8, GFP_KERNEL);
 
 	// Retrive current version
-	spin_lock_irqsave(&t150->settings.access_lock, flags);
+	mutex_lock(&t150->lock);
+	
 	errno = usb_control_msg(
 		t150->usb_device,
 		usb_rcvctrlpipe(t150->usb_device, 0),
 		86, 0xc1, 0, 0, fw_version, 8, SETTINGS_TIMEOUT
 	);
-	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
+
+	mutex_unlock(&t150->lock);
 
 	if(errno < 0)
 		printk(KERN_ERR "t150: Error %d while sending the control URB to retrive firmware version\n", errno);

--- a/t150/t150.c
+++ b/t150/t150.c
@@ -55,6 +55,7 @@ static inline int t150_constructor(struct t150 *t150,struct usb_interface *inter
 		error_code = -ENOMEM;
 		goto error1;
 	}
+	mutex_init(&t150->lock);
 	spin_lock_init(&t150->settings.access_lock);
 
 	// From xpad.c

--- a/t150/t150.c
+++ b/t150/t150.c
@@ -55,6 +55,7 @@ static inline int t150_constructor(struct t150 *t150,struct usb_interface *inter
 		error_code = -ENOMEM;
 		goto error1;
 	}
+	spin_lock_init(&t150->settings.access_lock);
 
 	// From xpad.c
 	for (i = 0; i < 2; i++)

--- a/t150/t150.h
+++ b/t150/t150.h
@@ -34,7 +34,6 @@ struct t150
 
 	struct {
 		spinlock_t access_lock;
-		unsigned long access_lock_flags;
 
 		uint8_t autocenter_force;
 		bool autocenter_enabled;

--- a/t150/t150.h
+++ b/t150/t150.h
@@ -1,3 +1,5 @@
+#include <linux/mutex.h>
+
 #define USB_THRUSTMASTER_VENDOR_ID	0x044f
 #define USB_T150_PRODUCT_ID		0xb677
 
@@ -31,6 +33,8 @@ struct t150
 	struct usb_anchor misc_ffb_ops;
 	struct urb *update_ffb_urbs[FF_MAX_EFFECTS][3];
 	unsigned update_ffb_free_slot;
+
+	struct mutex lock;
 
 	struct {
 		spinlock_t access_lock;


### PR DESCRIPTION
A small fix in install.sh, and a few locking fixes:
- Fix use of common IRQ flags variable in spinlock functions
- Initialise spinlock
- Fix the "BUG: scheduling while atomic" errors due to inappropriate use of spinlocks, by adding a mutex