### PR TITLE
Using kfree_sensitive over kzfree for kernels >= 5.9-rc1

### DIFF
--- a/hid-t150/forcefeedback.c
+++ b/hid-t150/forcefeedback.c
@@ -2,7 +2,7 @@
 static void t150_ff_free_urb(struct urb *urb) 
 {
 	//struct t150 *t150 = urb->context;
-	kzfree(urb->transfer_buffer);
+	KFREE(urb->transfer_buffer);
 	usb_free_urb(urb);
 }
 
@@ -22,7 +22,7 @@ static struct urb* t150_ff_alloc_urb(struct t150 *t150, const size_t buffer_size
 
 	urb = usb_alloc_urb(0, GFP_KERNEL);
 	if(!urb) {
-		kzfree(buffer);
+		KFREE(buffer);
 		return 0;
 	}
 
@@ -84,7 +84,7 @@ static inline void t150_free_ffb(struct t150 *t150)
 				continue;
 
 			usb_kill_urb(t150->update_ffb_urbs[i][j]);
-			kzfree(t150->update_ffb_urbs[i][j]->transfer_buffer);
+			KFREE(t150->update_ffb_urbs[i][j]->transfer_buffer);
 			usb_free_urb(t150->update_ffb_urbs[i][j]);
 		}
 }

--- a/hid-t150/forcefeedback.c
+++ b/hid-t150/forcefeedback.c
@@ -2,7 +2,7 @@
 static void t150_ff_free_urb(struct urb *urb) 
 {
 	//struct t150 *t150 = urb->context;
-	KFREE(urb->transfer_buffer);
+	kfree(urb->transfer_buffer);
 	usb_free_urb(urb);
 }
 
@@ -22,7 +22,7 @@ static struct urb* t150_ff_alloc_urb(struct t150 *t150, const size_t buffer_size
 
 	urb = usb_alloc_urb(0, GFP_KERNEL);
 	if(!urb) {
-		KFREE(buffer);
+		kfree(buffer);
 		return 0;
 	}
 
@@ -84,7 +84,7 @@ static inline void t150_free_ffb(struct t150 *t150)
 				continue;
 
 			usb_kill_urb(t150->update_ffb_urbs[i][j]);
-			KFREE(t150->update_ffb_urbs[i][j]->transfer_buffer);
+			kfree(t150->update_ffb_urbs[i][j]->transfer_buffer);
 			usb_free_urb(t150->update_ffb_urbs[i][j]);
 		}
 }

--- a/hid-t150/hid-t150.c
+++ b/hid-t150/hid-t150.c
@@ -201,17 +201,17 @@ static int __init t150_init(void)
 	else
 		return 0;
 
-err3:	KFREE(packet_input_close);
-err2:	KFREE(packet_input_what);
-err1:	KFREE(packet_input_open);
+err3:	kfree(packet_input_close);
+err2:	kfree(packet_input_what);
+err1:	kfree(packet_input_open);
 err0:	return errno;
 }
 
 static void __exit t150_exit(void)
 {
-	KFREE(packet_input_open);
-	KFREE(packet_input_what);
-	KFREE(packet_input_close);
+	kfree(packet_input_open);
+	kfree(packet_input_what);
+	kfree(packet_input_close);
 
 	hid_unregister_driver(&t150_driver);
 }

--- a/hid-t150/hid-t150.c
+++ b/hid-t150/hid-t150.c
@@ -11,6 +11,7 @@
 #include <linux/fixp-arith.h>
 #include <linux/spinlock.h>
 #include <linux/hid.h>
+#include <linux/version.h>
 
 #include "hid-t150.h"
 #include "input.h"
@@ -200,17 +201,17 @@ static int __init t150_init(void)
 	else
 		return 0;
 
-err3:	kzfree(packet_input_close);
-err2:	kzfree(packet_input_what);
-err1:	kzfree(packet_input_open);
+err3:	KFREE(packet_input_close);
+err2:	KFREE(packet_input_what);
+err1:	KFREE(packet_input_open);
 err0:	return errno;
 }
 
 static void __exit t150_exit(void)
 {
-	kzfree(packet_input_open);
-	kzfree(packet_input_what);
-	kzfree(packet_input_close);
+	KFREE(packet_input_open);
+	KFREE(packet_input_what);
+	KFREE(packet_input_close);
 
 	hid_unregister_driver(&t150_driver);
 }

--- a/hid-t150/hid-t150.c
+++ b/hid-t150/hid-t150.c
@@ -11,7 +11,6 @@
 #include <linux/fixp-arith.h>
 #include <linux/spinlock.h>
 #include <linux/hid.h>
-#include <linux/version.h>
 
 #include "hid-t150.h"
 #include "input.h"

--- a/hid-t150/hid-t150.h
+++ b/hid-t150/hid-t150.h
@@ -3,12 +3,6 @@
 #define USB_THRUSTMASTER_VENDOR_ID	0x044f
 #define USB_T150_PRODUCT_ID		0xb677
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,1)
-	#define KFREE(ptr) kfree_sensitive(ptr)
-#else
-	#define KFREE(ptr) kzfree(ptr)
-#endif
-
 struct joy_state_packet;
 struct ff_first;
 struct ff_second;

--- a/hid-t150/hid-t150.h
+++ b/hid-t150/hid-t150.h
@@ -3,6 +3,12 @@
 #define USB_THRUSTMASTER_VENDOR_ID	0x044f
 #define USB_T150_PRODUCT_ID		0xb677
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,1)
+	#define KFREE(ptr) kfree_sensitive(ptr)
+#else
+	#define KFREE(ptr) kzfree(ptr)
+#endif
+
 struct joy_state_packet;
 struct ff_first;
 struct ff_second;

--- a/hid-t150/settings.c
+++ b/hid-t150/settings.c
@@ -33,7 +33,7 @@ static int t150_set_gain(struct t150 *t150, uint8_t gain)
 
 	mutex_unlock(&t150->lock);
 
-	KFREE(buffer);
+	kfree(buffer);
 
 	return errno;
 }
@@ -59,7 +59,7 @@ static __always_inline int t150_set_autocenter(struct t150 *t150, uint8_t autoce
 
 	mutex_unlock(&t150->lock);
 
-	KFREE(buffer);
+	kfree(buffer);
 	return errno;
 }
 
@@ -85,7 +85,7 @@ static __always_inline int t150_set_enable_autocenter(struct t150 *t150, bool en
 
 	mutex_unlock(&t150->lock);
 
-	KFREE(buffer);
+	kfree(buffer);
 	return errno;
 }
 
@@ -111,7 +111,7 @@ static __always_inline int t150_set_range(struct t150 *t150, uint16_t range)
 
 	mutex_unlock(&t150->lock);
 
-	KFREE(buffer);
+	kfree(buffer);
 	return errno;
 }
 
@@ -190,6 +190,6 @@ static int t150_setup_task(struct t150 *t150)
 
 	hid_info(t150->hid_device,  "Setup completed! Firmware version is %d\n", t150->settings.firmware_version);
 
-	KFREE(fw_version);
+	kfree(fw_version);
 	return errno;
 }

--- a/hid-t150/settings.c
+++ b/hid-t150/settings.c
@@ -33,7 +33,7 @@ static int t150_set_gain(struct t150 *t150, uint8_t gain)
 
 	mutex_unlock(&t150->lock);
 
-	kzfree(buffer);
+	KFREE(buffer);
 
 	return errno;
 }
@@ -59,7 +59,7 @@ static __always_inline int t150_set_autocenter(struct t150 *t150, uint8_t autoce
 
 	mutex_unlock(&t150->lock);
 
-	kzfree(buffer);
+	KFREE(buffer);
 	return errno;
 }
 
@@ -85,7 +85,7 @@ static __always_inline int t150_set_enable_autocenter(struct t150 *t150, bool en
 
 	mutex_unlock(&t150->lock);
 
-	kzfree(buffer);
+	KFREE(buffer);
 	return errno;
 }
 
@@ -111,7 +111,7 @@ static __always_inline int t150_set_range(struct t150 *t150, uint16_t range)
 
 	mutex_unlock(&t150->lock);
 
-	kzfree(buffer);
+	KFREE(buffer);
 	return errno;
 }
 
@@ -190,6 +190,6 @@ static int t150_setup_task(struct t150 *t150)
 
 	hid_info(t150->hid_device,  "Setup completed! Firmware version is %d\n", t150->settings.firmware_version);
 
-	kzfree(fw_version);
+	KFREE(fw_version);
 	return errno;
 }


### PR DESCRIPTION
This modification is needed for the newer kernels as per https://github.com/torvalds/linux/commit/453431a54934d917153c65211b2dabf45562ca88.

I have also made the same changes to [hid-tminit](https://github.com/scarburato/hid-tminit) when this pull request is merged: https://github.com/scarburato/hid-tminit/pull/4.

This is tested on kernel version `5.10.5-arch1-1` but should be working on other kernels from `5.9.1` and up.