### PR TITLE
Fix path for device files

### DIFF
--- a/hid-t150/attributes.c
+++ b/hid-t150/attributes.c
@@ -6,42 +6,42 @@ static inline int t150_init_attributes(struct t150 *t150)
 	// @FIXME I do not know if it is desiradable to wait for URBs in probe() method...
 	t150_setup_task(t150);
 
-	errno = device_create_file(&t150->usb_device->dev, &dev_attr_autocenter);
+	errno = device_create_file(&t150->hid_device->dev, &dev_attr_autocenter);
 	if(errno)
 		return errno;
 
-	errno = device_create_file(&t150->usb_device->dev, &dev_attr_enable_autocenter);
+	errno = device_create_file(&t150->hid_device->dev, &dev_attr_enable_autocenter);
 	if(errno)
 		goto err1;
 
-	errno = device_create_file(&t150->usb_device->dev, &dev_attr_range);
+	errno = device_create_file(&t150->hid_device->dev, &dev_attr_range);
 	if(errno)
 		goto err2;
 
-	errno = device_create_file(&t150->usb_device->dev, &dev_attr_gain);
+	errno = device_create_file(&t150->hid_device->dev, &dev_attr_gain);
 	if(errno)
 		goto err3;
 
-	errno = device_create_file(&t150->usb_device->dev, &dev_attr_firmware_version);
+	errno = device_create_file(&t150->hid_device->dev, &dev_attr_firmware_version);
 	if(errno)
 		goto err4;
 
 	return 0;
 
-err4:	device_remove_file(&t150->usb_device->dev, &dev_attr_firmware_version);
-err3:	device_remove_file(&t150->usb_device->dev, &dev_attr_range);
-err2:	device_remove_file(&t150->usb_device->dev, &dev_attr_enable_autocenter);
-err1:	device_remove_file(&t150->usb_device->dev, &dev_attr_autocenter);
+err4:	device_remove_file(&t150->hid_device->dev, &dev_attr_firmware_version);
+err3:	device_remove_file(&t150->hid_device->dev, &dev_attr_range);
+err2:	device_remove_file(&t150->hid_device->dev, &dev_attr_enable_autocenter);
+err1:	device_remove_file(&t150->hid_device->dev, &dev_attr_autocenter);
 	return errno;
 }
 
 static inline void t150_free_attributes(struct t150 *t150)
 {
-	device_remove_file(&t150->usb_device->dev, &dev_attr_autocenter);
-	device_remove_file(&t150->usb_device->dev, &dev_attr_enable_autocenter);
-	device_remove_file(&t150->usb_device->dev, &dev_attr_range);
-	device_remove_file(&t150->usb_device->dev, &dev_attr_gain);
-	device_remove_file(&t150->usb_device->dev, &dev_attr_firmware_version);
+	device_remove_file(&t150->hid_device->dev, &dev_attr_autocenter);
+	device_remove_file(&t150->hid_device->dev, &dev_attr_enable_autocenter);
+	device_remove_file(&t150->hid_device->dev, &dev_attr_range);
+	device_remove_file(&t150->hid_device->dev, &dev_attr_gain);
+	device_remove_file(&t150->hid_device->dev, &dev_attr_firmware_version);
 }
 
 /**/


### PR DESCRIPTION
In readme it says:

> for example if you see `input: Thrustmaster T150 steering wheel as /devices/pci0000:00/0000:00:14.0/usb1/1-1/input/input27`
  39   │ then the attributes will be located at `sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/input/input27/device/`

checking in my system:

$ realpath /sys/devices/pci0000:00/0000:00:14.0/usb1/1-6/1-6:1.0/0003:044F:B677.002C/input/input87/device/
/sys/devices/pci0000:00/0000:00:14.0/usb1/1-6/1-6:1.0/0003:044F:B677.002C

This change write files there, currently they are write on 

/sys/devices/pci0000:00/0000:00:14.0/usb1/1-6/

This relates to https://github.com/berarma/oversteer/issues/132, a config manager for force feedback
