### PR TITLE
Add TMX Force Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Thrustmaster T150 Force Feedback Wheel Linux drivers
+# Thrustmaster T150 and TMX Force Feedback Wheel Linux drivers
 **DISCLAMER**
 *This is not an official driver from Thrustmaster and is provided without any kind of warranty. Loading and using this driver is at your own risk; I don't take responsibility for kernel panics, devices bricked or any other kind of inconvenience*
 
@@ -6,7 +6,8 @@
 
 ### What's working 👌
 + All axis and buttons of the wheel are reported
-+ You can set the range of the wheel from 270° to 1080°
++ You can set the range of the T150 wheel from 270° to 1080°
++ You can set the range of the TMX wheel from 270° to 900°
 + You can set the return force of the wheel from 0% to 100%
 + Force feedback (partially)
   * You can set the global force feedback scale from 0% to 100%
@@ -24,11 +25,13 @@
 - Firmware upgrades
 - Handling of range changes from the wheel
 
-## How to use the driver
-**Always put the switch of your wheel to the `PS3` position before plug it into your machine!**
-
 ### Switch the wheel from FFB to full T150
-Since kernel version 5.13, hid_thrustmaster automatically switch thrustmaster devices into full mode.
+Since kernel version 5.13, hid_thrustmaster automatically switch some thrustmaster devices into full mode. The T150 is covered by this driver. The TMX wheel does not have support in the hid_thrustmaster and requries either using [TMX-Driver](https://github.com/emtek995/TMX-driver) (kernel driver) or [tmdrv](https://github.com/her001/tmdrv) (python userspace driver) to intialize.
+
+## How to use the driver
+**For T150, always put the switch of your wheel to the `PS3` position before plug it into your machine!**
+For the TMX, plug the wheel into your machine and load your preffered intialization driver. The mode switch will only be used to swap the clutch and accelerator pedals if using the T3PA-Pro in hangdown mode.
+
 
 ### Setting up the wheel parameters
 You can edit the settings of each wheel attached to the machine by writing the sysfs attributes usually found in the 
@@ -40,7 +43,7 @@ This table contains a summary of each attribute
 
 |Attribute          |Value                         |Description                                                       |
 |-------------------|------------------------------|------------------------------------------------------------------|
-|`range`            |decimal from `270` to `1080`  |How far the wheel turns                                           |
+|`range`            |decimal from `270` to `1080`  |How far the wheel turns (TMX limited to 900)                      |
 |`autocenter`       |decimal from `0` to `100`     |The force used to re-center the wheel                             |
 |`enable_autocenter`|boolean `y` xor `n`           |Use the user defined return force or let the game handle it trough ffb|
 |`gain`             |decimal from `0` to `100`     |Force feedback intensity. 0 no effects are reproduced             |

--- a/hid-t150/attributes.c
+++ b/hid-t150/attributes.c
@@ -113,9 +113,9 @@ static ssize_t t150_store_range(struct device *dev, struct device_attribute *att
 	if(kstrtou16(buf, 10, &range))
 		return count;
 
-	if(t150->hid_device->product == 0xb677)
+	if(t150->hid_device->product == USB_T150_PRODUCT_ID)
 		dev_max_range = 1080;
-	else if (t150->hid_device->product == 0xb67f)
+	else if (t150->hid_device->product == USB_TMX_PRODUCT_ID)
 		dev_max_range = 900;
 
 	if(range < 270)

--- a/hid-t150/attributes.c
+++ b/hid-t150/attributes.c
@@ -94,7 +94,6 @@ static ssize_t t150_show_simulate_return_force(struct device *dev, struct device
 	int len;
 	struct t150 *t150 = dev_get_drvdata(dev);
 	unsigned long flags;
-
 	spin_lock_irqsave(&t150->settings.access_lock, flags);
 	len = sprintf(buf, "%c\n", t150->settings.autocenter_enabled ? 'y' : 'n');
 	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
@@ -106,18 +105,25 @@ static ssize_t t150_store_range(struct device *dev, struct device_attribute *att
 	const char *buf, size_t count)
 {
 	uint16_t range;
+	int dev_max_range;
+
 	struct t150 *t150 = dev_get_drvdata(dev);
 
 	// If mallformed input leave...
 	if(kstrtou16(buf, 10, &range))
 		return count;
 
+	if(t150->hid_device->product == 0xb677)
+		dev_max_range = 1080;
+	else if (t150->hid_device->product == 0xb67f)
+		dev_max_range = 900;
+
 	if(range < 270)
 		range = 270;
-	else if (range > 1080)
-		range = 1080;
+	else if (range > dev_max_range)
+		range = dev_max_range;
 
-	range = DIV_ROUND_CLOSEST((range * 0xffff), 1080);
+	range = DIV_ROUND_CLOSEST((range * 0xffff), dev_max_range);
 
 	t150_set_range(t150, range);
 
@@ -130,8 +136,15 @@ static ssize_t t150_show_range(struct device *dev, struct device_attribute *attr
 	struct t150 *t150 = dev_get_drvdata(dev);
 	unsigned long flags;
 
+	int dev_max_range;
+
+	if(t150->hid_device->product == 0xb677)
+		dev_max_range = 1080;
+	else if (t150->hid_device->product == 0xb67f)
+		dev_max_range = 900;
+
 	spin_lock_irqsave(&t150->settings.access_lock, flags);
-	len = sprintf(buf, "%d\n", DIV_ROUND_CLOSEST(t150->settings.range * 1080, 0xffff));
+	len = sprintf(buf, "%d\n", DIV_ROUND_CLOSEST(t150->settings.range * dev_max_range, 0xffff));
 	spin_unlock_irqrestore(&t150->settings.access_lock, flags);
 
 	return len;

--- a/hid-t150/hid-t150.c
+++ b/hid-t150/hid-t150.c
@@ -157,6 +157,7 @@ static void t150_remove(struct hid_device *hid_device)
 static struct hid_device_id t150_table[] =
 {
 	{ HID_USB_DEVICE(USB_THRUSTMASTER_VENDOR_ID, USB_T150_PRODUCT_ID) },
+	{ HID_USB_DEVICE(USB_THRUSTMASTER_VENDOR_ID, USB_TMX_PRODUCT_ID) },
 	{} /* Terminating entry */
 };
 MODULE_DEVICE_TABLE (hid, t150_table);

--- a/hid-t150/hid-t150.h
+++ b/hid-t150/hid-t150.h
@@ -2,6 +2,7 @@
 
 #define USB_THRUSTMASTER_VENDOR_ID	0x044f
 #define USB_T150_PRODUCT_ID		0xb677
+#define USB_TMX_PRODUCT_ID		0xb67f
 
 struct joy_state_packet;
 struct ff_first;


### PR DESCRIPTION
The TMX Force Feedback is the XBOX version of the T150. The API is the same. The only difference of note for this driver is that the range of the TMX is 900, however setting it to 1080 doesn't seem to negatively affect the steering and `evtest` reports full motion when set to 900 or 1080. 

It should also be noted that the hid_thrustmaster driver does not fully init the TMX and requires https://github.com/pastaq/TMX-driver or https://github.com/pastaq/tmdrv to initialize. 