### PR TITLE
Fix lsmod command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The rule in the example should set the turning range to 270°.
 ## How to install and load the driver
 You can try to run `install.sh` as root, the script should: copy the udev rules and other files in their appropriate positions, build and install the DKMS modules and add them to the list of modules to be loaded at boot. 
 
-To check if the modules are loaded check the output of `lsmod | grep hid-t150`.
+To check if the modules are loaded check the output of `lsmod | grep hid_t150`.
 
 ### Manually 
 Copy the udev rules into `/etc/udev/rules.d/` and reload the udev rules (or reboot)...


### PR DESCRIPTION
The command in the documentation didn't work for me. I looked at `lsmod` to see the correct name for my device. I'm not sure if this is an issue with everyone. 